### PR TITLE
Check bit "long mode active"

### DIFF
--- a/mythril/src/emulate/memio.rs
+++ b/mythril/src/emulate/memio.rs
@@ -415,7 +415,11 @@ fn process_memio_op(
 
     let efer = vcpu.vmcs.read_field(vmcs::VmcsField::GuestIa32Efer)?;
     // TODO: 16bit support
-    let mode = if efer & 0x00000100 != 0 { 64 } else { 32 };
+    let mode = if efer & (1 << 8) != 0 && efer & (1 << 10) != 0 {
+        64
+    } else {
+        32
+    };
 
     let mut decoder =
         iced_x86::Decoder::new(mode, &bytes, iced_x86::DecoderOptions::NONE);


### PR DESCRIPTION
While testing on baremetal, I encountered a bug in process_memio_op. An instruction was not decoded in the right mode.
It seems to be a bug in mythil not checking the right bit in the field IA32_EFER of the vmcs. Bits "long mode enable" and especially "long mode active" must be checked. (see here https://wiki.osdev.org/CPU_Registers_x86-64#IA32_EFER)